### PR TITLE
Drain resettable loggers on kernel reset and implement TerminableInterace

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -145,6 +145,27 @@ jobs:
       - name: Run Mago Guard
         run: vendor/bin/mago guard --reporting-format=github
 
+  igor_php:
+    name: 🧟️ Memory Analysis (Igor PHP)
+    needs: build
+    runs-on: ${{ matrix.operating-system }}
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJSON(needs.build.outputs.matrix) }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php-version }}
+          tools: composer:v2
+      - uses: actions/cache@v4
+        with:
+          path: ~/.composer/cache
+          key: ${{ runner.os }}-php-${{ matrix.php-version }}-composer-${{ hashFiles('**/composer.lock') }}
+      - run: composer install --no-progress --prefer-dist
+      - name: Run Igor PHP
+        run: vendor/bin/igor-php .
+
   secret_scan:
     name: 🕵️ Secret Scanning (TruffleHog)
     needs: build

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -31,7 +31,7 @@ jobs:
       matrix: ${{ fromJSON(needs.prepare.outputs.matrix) }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
@@ -44,7 +44,7 @@ jobs:
         run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
 
       - name: Cache Composer dependencies
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ${{ steps.composer-cache.outputs.dir }}
           key: ${{ runner.os }}-php-${{ matrix.php-version }}-composer-${{ hashFiles('**/composer.lock') }}
@@ -63,14 +63,14 @@ jobs:
       matrix: ${{ fromJSON(needs.build.outputs.matrix) }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php-version }}
           tools: composer:v2
       - name: Cache Composer dependencies
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.composer/cache
           key: ${{ runner.os }}-php-${{ matrix.php-version }}-composer-${{ hashFiles('**/composer.lock') }}
@@ -88,14 +88,14 @@ jobs:
       matrix: ${{ fromJSON(needs.build.outputs.matrix) }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php-version }}
           tools: composer:v2
       - name: Cache and Install
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.composer/cache
           key: ${{ runner.os }}-php-${{ matrix.php-version }}-composer-${{ hashFiles('**/composer.lock') }}
@@ -111,12 +111,12 @@ jobs:
       fail-fast: false
       matrix: ${{ fromJSON(needs.build.outputs.matrix) }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php-version }}
           tools: composer:v2
-      - uses: actions/cache@v4
+      - uses: actions/cache@v5
         with:
           path: ~/.composer/cache
           key: ${{ runner.os }}-php-${{ matrix.php-version }}-composer-${{ hashFiles('**/composer.lock') }}
@@ -132,12 +132,12 @@ jobs:
       fail-fast: false
       matrix: ${{ fromJSON(needs.build.outputs.matrix) }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php-version }}
           tools: composer:v2
-      - uses: actions/cache@v4
+      - uses: actions/cache@v5
         with:
           path: ~/.composer/cache
           key: ${{ runner.os }}-php-${{ matrix.php-version }}-composer-${{ hashFiles('**/composer.lock') }}
@@ -153,12 +153,12 @@ jobs:
       fail-fast: false
       matrix: ${{ fromJSON(needs.build.outputs.matrix) }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php-version }}
           tools: composer:v2
-      - uses: actions/cache@v4
+      - uses: actions/cache@v5
         with:
           path: ~/.composer/cache
           key: ${{ runner.os }}-php-${{ matrix.php-version }}-composer-${{ hashFiles('**/composer.lock') }}
@@ -175,7 +175,7 @@ jobs:
       matrix: ${{ fromJSON(needs.build.outputs.matrix) }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
@@ -195,19 +195,19 @@ jobs:
       fail-fast: false
       matrix: ${{ fromJSON(needs.build.outputs.matrix) }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php-version }}
           tools: composer:v2
-      - uses: actions/cache@v4
+      - uses: actions/cache@v5
         with:
           path: ~/.composer/cache
           key: ${{ runner.os }}-php-${{ matrix.php-version }}-composer-${{ hashFiles('**/composer.lock') }}
       - name: Generate SBOM
         run: composer install && composer CycloneDX:make-sbom --output-format=json --output-file=bom.json
       - name: Upload SBOM Artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: sbom-cyclonedx
           path: bom.json
@@ -220,12 +220,12 @@ jobs:
       fail-fast: false
       matrix: ${{ fromJSON(needs.build.outputs.matrix) }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php-version }}
           tools: composer:v2
-      - uses: actions/cache@v4
+      - uses: actions/cache@v5
         with:
           path: ~/.composer/cache
           key: ${{ runner.os }}-php-${{ matrix.php-version }}-composer-${{ hashFiles('**/composer.lock') }}
@@ -244,14 +244,14 @@ jobs:
       matrix: ${{ fromJSON(needs.build.outputs.matrix) }}
     if: failure() || success()
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php-version }}
           extensions: gd, pgsql, pdo_mysql, pdo_pgsql, gmp, fileinfo, intl, opcache, xml, iconv, redis, mailparse
           coverage: xdebug
           tools: composer:v2
-      - uses: actions/cache@v4
+      - uses: actions/cache@v5
         with:
           path: ~/.composer/cache
           key: ${{ runner.os }}-php-${{ matrix.php-version }}-composer-${{ hashFiles('**/composer.lock') }}
@@ -259,7 +259,7 @@ jobs:
       - name: Run PHPUnit tests
         run: vendor/bin/phpunit --coverage-clover ./var/data/phpunit-coverage/clover.xml
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@v6
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: ./var/data/phpunit-coverage/clover.xml

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,16 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and the project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 Released in lockstep with the Waffle Commons umbrella tag.
 
-## [Unreleased] — targeting `0.1.0-beta2`
+## [Unreleased] — targeting `0.1.0-beta3`
+
+**Theme: identity federation & stateless persistence (ecosystem wave).**
+
+### Changed
+- `AbstractKernel` drains resettable loggers on kernel reset and implements the new `Contracts\Core\TerminableInterface` (post-response teardown hook for the FrankenPHP worker loop).
+- Dependency-injection behaviour documented inline in `AbstractController` / `AbstractKernel` (no behavioural change).
+- Lockstep version bump; `composer.lock` refreshed with the beta-3 dependency wave.
+
+## [0.1.0-beta2] — 2026-05-29
 
 ### Changed
 - Lockstep version bump only. No behavioural changes since `0.1.0-beta1`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and the project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 Released in lockstep with the Waffle Commons umbrella tag.
 
-## [Unreleased] — targeting `0.1.0-beta3`
+## [0.1.0-beta3] — 2026-06-07
 
 **Theme: identity federation & stateless persistence (ecosystem wave).**
 
@@ -13,6 +13,11 @@ Released in lockstep with the Waffle Commons umbrella tag.
 - `AbstractKernel` drains resettable loggers on kernel reset and implements the new `Contracts\Core\TerminableInterface` (post-response teardown hook for the FrankenPHP worker loop).
 - Dependency-injection behaviour documented inline in `AbstractController` / `AbstractKernel` (no behavioural change).
 - Lockstep version bump; `composer.lock` refreshed with the beta-3 dependency wave.
+
+## [0.1.0-beta2.1] — 2026-05-30
+
+### Changed
+- Lockstep re-tag of `0.1.0-beta2` (umbrella housekeeping patch) — no source changes in this component.
 
 ## [0.1.0-beta2] — 2026-05-29
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 Waffle — the Kernel
 ===================
 
-> **Release:** `v0.1.0-beta2` &nbsp;|&nbsp; [`CHANGELOG.md`](./CHANGELOG.md)
+> **Release:** `0.1.0-beta3` &nbsp;|&nbsp; [`CHANGELOG.md`](./CHANGELOG.md)
 
 The application kernel. Orchestrates request handling against the PSR-15 middleware stack, dispatches `RequestReceivedEvent` / `ResponseGeneratedEvent` / `TerminateEvent`, and resolves controllers via the container. The kernel itself stays agnostic of routing, security, logging, and HTTP — every concrete dependency is injected.
 

--- a/composer.json
+++ b/composer.json
@@ -37,13 +37,15 @@
         "carthage-software/mago": "^1.29",
         "vimeo/psalm": "^6.16",
         "php-mock/php-mock-phpunit": "^2.15",
-        "cyclonedx/cyclonedx-php-composer": "^6.2"
+        "cyclonedx/cyclonedx-php-composer": "^6.2",
+        "igor-php/igor-php": "^0.6.3"
     },
     "scripts": {
         "formatter": "vendor/bin/mago fmt",
         "linter": "vendor/bin/mago lint",
         "analyzer": "vendor/bin/mago analyze",
         "guard": "vendor/bin/mago guard",
+        "igor": "vendor/bin/igor-php .",
         "phpunit": "vendor/bin/phpunit --log-junit var/data/phpunit-coverage/junit.xml --coverage-html var/data/phpunit-coverage",
         "benchmark": [
             "Composer\\Config::disableProcessTimeout",

--- a/composer.lock
+++ b/composer.lock
@@ -483,12 +483,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/waffle-commons/contracts.git",
-                "reference": "7acfd0427a54b0b6908ea2c4e064f2e5526f8d5b"
+                "reference": "0f70ec3375f0ec03a7e4d4ed87e8cc974506c935"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/waffle-commons/contracts/zipball/7acfd0427a54b0b6908ea2c4e064f2e5526f8d5b",
-                "reference": "7acfd0427a54b0b6908ea2c4e064f2e5526f8d5b",
+                "url": "https://api.github.com/repos/waffle-commons/contracts/zipball/0f70ec3375f0ec03a7e4d4ed87e8cc974506c935",
+                "reference": "0f70ec3375f0ec03a7e4d4ed87e8cc974506c935",
                 "shasum": ""
             },
             "require": {
@@ -532,7 +532,7 @@
                 "issues": "https://github.com/waffle-commons/contracts/issues",
                 "source": "https://github.com/waffle-commons/contracts/tree/main"
             },
-            "time": "2026-05-30T18:44:28+00:00"
+            "time": "2026-06-07T00:39:38+00:00"
         },
         {
             "name": "waffle-commons/utils",
@@ -540,12 +540,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/waffle-commons/utils.git",
-                "reference": "434d5929dc75a62050b726ba2cb3532d680557d4"
+                "reference": "10fbc6e9f824ba2635e70acf0e96186eb966d552"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/waffle-commons/utils/zipball/434d5929dc75a62050b726ba2cb3532d680557d4",
-                "reference": "434d5929dc75a62050b726ba2cb3532d680557d4",
+                "url": "https://api.github.com/repos/waffle-commons/utils/zipball/10fbc6e9f824ba2635e70acf0e96186eb966d552",
+                "reference": "10fbc6e9f824ba2635e70acf0e96186eb966d552",
                 "shasum": ""
             },
             "require": {
@@ -555,6 +555,7 @@
             "require-dev": {
                 "carthage-software/mago": "^1.29",
                 "cyclonedx/cyclonedx-php-composer": "^6.2",
+                "igor-php/igor-php": "^0.6.3",
                 "php-mock/php-mock-phpunit": "^2.15",
                 "phpunit/phpunit": "^12.5",
                 "vimeo/psalm": "^6.16"
@@ -581,7 +582,7 @@
                 "issues": "https://github.com/waffle-commons/utils/issues",
                 "source": "https://github.com/waffle-commons/utils/tree/main"
             },
-            "time": "2026-05-30T18:48:59+00:00"
+            "time": "2026-06-07T00:40:55+00:00"
         }
     ],
     "packages-dev": [

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "4524faf33eb57b15f4f4b8acdf358027",
+    "content-hash": "7cb3e73f6400704a766fa6591b955db3",
     "packages": [
         {
             "name": "psr/cache",
@@ -1110,16 +1110,16 @@
         },
         {
             "name": "amphp/process",
-            "version": "v2.0.3",
+            "version": "v2.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/amphp/process.git",
-                "reference": "52e08c09dec7511d5fbc1fb00d3e4e79fc77d58d"
+                "reference": "583959df17d00304ad7b0b32285373f985935643"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/amphp/process/zipball/52e08c09dec7511d5fbc1fb00d3e4e79fc77d58d",
-                "reference": "52e08c09dec7511d5fbc1fb00d3e4e79fc77d58d",
+                "url": "https://api.github.com/repos/amphp/process/zipball/583959df17d00304ad7b0b32285373f985935643",
+                "reference": "583959df17d00304ad7b0b32285373f985935643",
                 "shasum": ""
             },
             "require": {
@@ -1133,7 +1133,7 @@
                 "amphp/php-cs-fixer-config": "^2",
                 "amphp/phpunit-util": "^3",
                 "phpunit/phpunit": "^9",
-                "psalm/phar": "^5.4"
+                "psalm/phar": "6.16.1"
             },
             "type": "library",
             "autoload": {
@@ -1166,7 +1166,7 @@
             "homepage": "https://amphp.org/process",
             "support": {
                 "issues": "https://github.com/amphp/process/issues",
-                "source": "https://github.com/amphp/process/tree/v2.0.3"
+                "source": "https://github.com/amphp/process/tree/v2.1.0"
             },
             "funding": [
                 {
@@ -1174,7 +1174,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2024-04-19T03:13:44+00:00"
+            "time": "2026-05-31T15:11:55+00:00"
         },
         {
             "name": "amphp/serialization",
@@ -1404,16 +1404,16 @@
         },
         {
             "name": "carthage-software/mago",
-            "version": "1.29.0",
+            "version": "1.30.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/carthage-software/mago.git",
-                "reference": "8aab53f6d004f9a6e85128c365d3d28737fdb272"
+                "reference": "0e8a3644d974984069fa27b0ffbb44123b1b74cd"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/carthage-software/mago/zipball/8aab53f6d004f9a6e85128c365d3d28737fdb272",
-                "reference": "8aab53f6d004f9a6e85128c365d3d28737fdb272",
+                "url": "https://api.github.com/repos/carthage-software/mago/zipball/0e8a3644d974984069fa27b0ffbb44123b1b74cd",
+                "reference": "0e8a3644d974984069fa27b0ffbb44123b1b74cd",
                 "shasum": ""
             },
             "require": {
@@ -1451,7 +1451,7 @@
             ],
             "support": {
                 "issues": "https://github.com/carthage-software/mago/issues",
-                "source": "https://github.com/carthage-software/mago/tree/1.29.0"
+                "source": "https://github.com/carthage-software/mago/tree/1.30.0"
             },
             "funding": [
                 {
@@ -1459,7 +1459,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2026-05-23T18:53:33+00:00"
+            "time": "2026-06-04T15:46:37+00:00"
         },
         {
             "name": "composer/pcre",
@@ -1761,16 +1761,16 @@
         },
         {
             "name": "cyclonedx/cyclonedx-library",
-            "version": "v4.0.0",
+            "version": "v4.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/CycloneDX/cyclonedx-php-library.git",
-                "reference": "c95a371894c4e32bea42bfa024f2ab5092cbb292"
+                "reference": "6a4f249cecf3b4211ad6bd8cee30fca89e0f81e5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/CycloneDX/cyclonedx-php-library/zipball/c95a371894c4e32bea42bfa024f2ab5092cbb292",
-                "reference": "c95a371894c4e32bea42bfa024f2ab5092cbb292",
+                "url": "https://api.github.com/repos/CycloneDX/cyclonedx-php-library/zipball/6a4f249cecf3b4211ad6bd8cee30fca89e0f81e5",
+                "reference": "6a4f249cecf3b4211ad6bd8cee30fca89e0f81e5",
                 "shasum": ""
             },
             "require": {
@@ -1852,7 +1852,7 @@
                     "type": "other"
                 }
             ],
-            "time": "2026-02-17T11:46:50+00:00"
+            "time": "2026-06-04T10:31:45+00:00"
         },
         {
             "name": "cyclonedx/cyclonedx-php-composer",
@@ -2229,6 +2229,56 @@
                 }
             ],
             "time": "2025-08-14T07:29:31+00:00"
+        },
+        {
+            "name": "igor-php/igor-php",
+            "version": "v0.6.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/igor-php/igor-php.git",
+                "reference": "9aecff9843f27eb9adb674172abfae7b2d18d295"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/igor-php/igor-php/zipball/9aecff9843f27eb9adb674172abfae7b2d18d295",
+                "reference": "9aecff9843f27eb9adb674172abfae7b2d18d295",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1"
+            },
+            "bin": [
+                "bin/igor-php"
+            ],
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "IgorPhp\\IgorBundle\\": "src/php/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Kevin MARTINS",
+                    "email": "kevin.martins@me.com"
+                }
+            ],
+            "description": "The faithful assistant for your FrankenPHP Workers.",
+            "keywords": [
+                "frankenphp",
+                "linter",
+                "static-analysis",
+                "symfony",
+                "worker"
+            ],
+            "support": {
+                "issues": "https://github.com/igor-php/igor-php/issues",
+                "source": "https://github.com/igor-php/igor-php/tree/v0.6.3"
+            },
+            "time": "2026-05-26T20:17:14+00:00"
         },
         {
             "name": "kelunik/certificate",
@@ -3445,16 +3495,16 @@
         },
         {
             "name": "phpunit/php-code-coverage",
-            "version": "12.5.6",
+            "version": "12.5.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
-                "reference": "876099a072646c7745f673d7aeab5382c4439691"
+                "reference": "186dab580576598076de6818596d12b61801880e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/876099a072646c7745f673d7aeab5382c4439691",
-                "reference": "876099a072646c7745f673d7aeab5382c4439691",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/186dab580576598076de6818596d12b61801880e",
+                "reference": "186dab580576598076de6818596d12b61801880e",
                 "shasum": ""
             },
             "require": {
@@ -3465,13 +3515,13 @@
                 "php": ">=8.3",
                 "phpunit/php-text-template": "^5.0",
                 "sebastian/complexity": "^5.0",
-                "sebastian/environment": "^8.0.3",
-                "sebastian/lines-of-code": "^4.0",
+                "sebastian/environment": "^8.1.2",
+                "sebastian/lines-of-code": "^4.0.1",
                 "sebastian/version": "^6.0",
                 "theseer/tokenizer": "^2.0.1"
             },
             "require-dev": {
-                "phpunit/phpunit": "^12.5.1"
+                "phpunit/phpunit": "^12.5.28"
             },
             "suggest": {
                 "ext-pcov": "PHP extension that provides line coverage",
@@ -3509,7 +3559,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/php-code-coverage/issues",
                 "security": "https://github.com/sebastianbergmann/php-code-coverage/security/policy",
-                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/12.5.6"
+                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/12.5.7"
             },
             "funding": [
                 {
@@ -3529,7 +3579,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-04-15T08:23:17+00:00"
+            "time": "2026-06-01T13:24:19+00:00"
         },
         {
             "name": "phpunit/php-file-iterator",
@@ -3790,16 +3840,16 @@
         },
         {
             "name": "phpunit/phpunit",
-            "version": "12.5.28",
+            "version": "12.5.29",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "5895d05f5bf421ed230fbd76e1277e4b8955def4"
+                "reference": "9aa66a47db3ea70f1a468e66dd969f67e594945a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/5895d05f5bf421ed230fbd76e1277e4b8955def4",
-                "reference": "5895d05f5bf421ed230fbd76e1277e4b8955def4",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/9aa66a47db3ea70f1a468e66dd969f67e594945a",
+                "reference": "9aa66a47db3ea70f1a468e66dd969f67e594945a",
                 "shasum": ""
             },
             "require": {
@@ -3813,7 +3863,7 @@
                 "phar-io/manifest": "^2.0.4",
                 "phar-io/version": "^3.2.1",
                 "php": ">=8.3",
-                "phpunit/php-code-coverage": "^12.5.6",
+                "phpunit/php-code-coverage": "^12.5.7",
                 "phpunit/php-file-iterator": "^6.0.1",
                 "phpunit/php-invoker": "^6.0.0",
                 "phpunit/php-text-template": "^5.0.0",
@@ -3823,7 +3873,7 @@
                 "sebastian/diff": "^7.0.0",
                 "sebastian/environment": "^8.1.2",
                 "sebastian/exporter": "^7.0.3",
-                "sebastian/global-state": "^8.0.2",
+                "sebastian/global-state": "^8.0.3",
                 "sebastian/object-enumerator": "^7.0.0",
                 "sebastian/recursion-context": "^7.0.1",
                 "sebastian/type": "^6.0.4",
@@ -3868,7 +3918,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/phpunit/issues",
                 "security": "https://github.com/sebastianbergmann/phpunit/security/policy",
-                "source": "https://github.com/sebastianbergmann/phpunit/tree/12.5.28"
+                "source": "https://github.com/sebastianbergmann/phpunit/tree/12.5.29"
             },
             "funding": [
                 {
@@ -3876,7 +3926,7 @@
                     "type": "other"
                 }
             ],
-            "time": "2026-05-27T14:01:10+00:00"
+            "time": "2026-06-04T06:14:42+00:00"
         },
         {
             "name": "psr/http-factory",
@@ -4459,26 +4509,26 @@
         },
         {
             "name": "sebastian/global-state",
-            "version": "8.0.2",
+            "version": "8.0.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/global-state.git",
-                "reference": "ef1377171613d09edd25b7816f05be8313f9115d"
+                "reference": "b164d3274d6537ab462591c5755f76a8f5b1aae9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/global-state/zipball/ef1377171613d09edd25b7816f05be8313f9115d",
-                "reference": "ef1377171613d09edd25b7816f05be8313f9115d",
+                "url": "https://api.github.com/repos/sebastianbergmann/global-state/zipball/b164d3274d6537ab462591c5755f76a8f5b1aae9",
+                "reference": "b164d3274d6537ab462591c5755f76a8f5b1aae9",
                 "shasum": ""
             },
             "require": {
                 "php": ">=8.3",
                 "sebastian/object-reflector": "^5.0",
-                "sebastian/recursion-context": "^7.0"
+                "sebastian/recursion-context": "^7.0.1"
             },
             "require-dev": {
                 "ext-dom": "*",
-                "phpunit/phpunit": "^12.0"
+                "phpunit/phpunit": "^12.5.28"
             },
             "type": "library",
             "extra": {
@@ -4509,7 +4559,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/global-state/issues",
                 "security": "https://github.com/sebastianbergmann/global-state/security/policy",
-                "source": "https://github.com/sebastianbergmann/global-state/tree/8.0.2"
+                "source": "https://github.com/sebastianbergmann/global-state/tree/8.0.3"
             },
             "funding": [
                 {
@@ -4529,7 +4579,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-08-29T11:29:25+00:00"
+            "time": "2026-06-01T15:10:33+00:00"
         },
         {
             "name": "sebastian/lines-of-code",

--- a/igor.json
+++ b/igor.json
@@ -1,0 +1,11 @@
+{
+    "exclude": [
+        "vendor",
+        "tests",
+        "var"
+    ],
+    "safe_namespaces": [
+        "Waffle\\Commons\\Contracts\\"
+    ],
+    "verbose": false
+}

--- a/src/Abstract/AbstractController.php
+++ b/src/Abstract/AbstractController.php
@@ -20,6 +20,7 @@ abstract class AbstractController implements BaseControllerInterface
      */
     public function setResponseFactory(ResponseFactoryInterface $responseFactory): void
     {
+        // @igor-ignore: setter DI wired once per controller instantiation by ControllerDispatcher; per-request, not shared
         $this->responseFactory = $responseFactory;
     }
 

--- a/src/Abstract/AbstractKernel.php
+++ b/src/Abstract/AbstractKernel.php
@@ -15,11 +15,13 @@ use Waffle\Commons\Contracts\Config\ConfigInterface;
 use Waffle\Commons\Contracts\Constant\Constant;
 use Waffle\Commons\Contracts\Container\ContainerInterface;
 use Waffle\Commons\Contracts\Core\KernelInterface;
+use Waffle\Commons\Contracts\Core\TerminableInterface;
 use Waffle\Commons\Contracts\EventDispatcher\EventDispatcherInterface;
 use Waffle\Commons\Contracts\Handler\ArgumentResolverInterface;
 use Waffle\Commons\Contracts\Pipeline\MiddlewareStackInterface;
 use Waffle\Commons\Contracts\Security\SecurityInterface;
 use Waffle\Commons\Contracts\Service\ReflectionServiceInterface;
+use Waffle\Commons\Contracts\Service\ResettableInterface;
 use Waffle\Core\System;
 use Waffle\Event\RequestReceivedEvent;
 use Waffle\Event\ResponseGeneratedEvent;
@@ -33,7 +35,7 @@ use Waffle\Handler\ControllerArgumentResolver;
 use Waffle\Handler\ControllerDispatcher;
 use Waffle\Service\ReflectionService;
 
-abstract class AbstractKernel implements KernelInterface
+abstract class AbstractKernel implements KernelInterface, TerminableInterface
 {
     protected string $environment = Constant::ENV_PROD;
 
@@ -140,6 +142,7 @@ abstract class AbstractKernel implements KernelInterface
      * Dispatches a terminate event for heavy async tasks after response emission.
      * Call this from Runtime after emit() and before reset().
      */
+    #[\Override]
     public function terminate(ServerRequestInterface $request, ResponseInterface $response): void
     {
         if ($this->dispatcher === null) {
@@ -334,11 +337,16 @@ abstract class AbstractKernel implements KernelInterface
     /**
      * {@inheritdoc}
      */
+    #[\Override]
     public function reset(): void
     {
         $this->container->reset();
 
-        // TODO: clean buffered logger
+        // Drain any buffered logger so log entries never bleed across requests in
+        // worker mode. Decoupled: only loggers that opt into ResettableInterface.
+        if ($this->logger instanceof ResettableInterface) {
+            $this->logger->reset();
+        }
     }
 
     private function validateState(ServerRequestInterface $request): void

--- a/src/Abstract/AbstractKernel.php
+++ b/src/Abstract/AbstractKernel.php
@@ -61,6 +61,7 @@ abstract class AbstractKernel implements KernelInterface, TerminableInterface
      */
     public function setContainerImplementation(PsrContainerInterface $container): void
     {
+        // @igor-ignore: boot-time setter DI; injected once before requests, persists for the worker lifetime
         $this->innerContainer = $container;
     }
 
@@ -69,21 +70,25 @@ abstract class AbstractKernel implements KernelInterface, TerminableInterface
      */
     public function setConfiguration(ConfigInterface $config): void
     {
+        // @igor-ignore: boot-time setter DI; injected once before requests, persists for the worker lifetime
         $this->config = $config;
     }
 
     public function setSecurity(SecurityInterface $security): void
     {
+        // @igor-ignore: boot-time setter DI; injected once before requests, persists for the worker lifetime
         $this->security = $security;
     }
 
     public function setMiddlewareStack(MiddlewareStackInterface $stack): void
     {
+        // @igor-ignore: boot-time setter DI; injected once before requests, persists for the worker lifetime
         $this->middlewareStack = $stack;
     }
 
     public function setEventDispatcher(EventDispatcherInterface $dispatcher): void
     {
+        // @igor-ignore: boot-time setter DI; injected once before requests, persists for the worker lifetime
         $this->dispatcher = $dispatcher;
     }
 
@@ -182,6 +187,7 @@ abstract class AbstractKernel implements KernelInterface, TerminableInterface
         // mutating global state (the prior `putenv($appEnv)` was both a latent
         // bug — missing '=' sentinel — and a worker-mode safety hazard).
         $envVar = getenv(Constant::APP_ENV);
+        // @igor-ignore: one-time boot read of APP_ENV; persists for the worker lifetime, not per request
         $this->environment = is_string($envVar) && $envVar !== '' ? $envVar : Constant::ENV_PROD;
 
         return $this;
@@ -219,6 +225,7 @@ abstract class AbstractKernel implements KernelInterface, TerminableInterface
         // The container is now expected to be fully configured (and potentially decorated) by the Runtime/Factory.
         // We cast it to our interface to support set() operations if available.
         if ($this->innerContainer instanceof ContainerInterface) {
+            // @igor-ignore: one-time boot wiring, guarded by $booted; persists for the worker lifetime
             $this->container = $this->innerContainer;
         } else {
             // Let's assume the user injects Waffle\Commons\Contracts\Container\ContainerInterface.
@@ -239,6 +246,7 @@ abstract class AbstractKernel implements KernelInterface, TerminableInterface
             );
         }
 
+        // @igor-ignore: one-time boot wiring, guarded by $booted; persists for the worker lifetime
         $this->system = new System(security: $this->security)->boot(kernel: $this);
 
         $this->registerDefaultTerminalHandler();
@@ -248,6 +256,7 @@ abstract class AbstractKernel implements KernelInterface, TerminableInterface
             $this->container->lock();
         }
 
+        // @igor-ignore: one-shot boot latch; flipped once after configure(), never per request
         $this->booted = true;
     }
 

--- a/tests/src/Abstract/AbstractKernelTest.php
+++ b/tests/src/Abstract/AbstractKernelTest.php
@@ -22,6 +22,7 @@ use Waffle\Commons\Contracts\Constant\Constant;
 use Waffle\Commons\Contracts\Container\ContainerInterface;
 use Waffle\Commons\Contracts\Routing\RouterInterface;
 use Waffle\Commons\Contracts\Security\SecurityInterface;
+use Waffle\Commons\Contracts\Service\ResettableInterface;
 use Waffle\Core\BaseController;
 use Waffle\Core\System; // Fix: Add missing import
 use Waffle\Exception\Container\ContainerException;
@@ -425,6 +426,34 @@ class AbstractKernelTest extends TestCase
 
         $kernel = new WebKernel(configDir: $this->testConfigDir, environment: 'dev', container: $container);
         $kernel->reset();
+    }
+
+    public function testResetAlsoDrainsAResettableLogger(): void
+    {
+        $container = $this->createMock(ContainerInterface::class);
+        $container->expects(static::once())->method('reset');
+
+        // A buffered logger that opts into ResettableInterface must be drained on
+        // reset() so log state never bleeds from request N into request N+1.
+        $logger = new class extends NullLogger implements ResettableInterface {
+            public bool $wasReset = false;
+
+            #[\Override]
+            public function reset(): void
+            {
+                $this->wasReset = true;
+            }
+        };
+
+        $kernel = new WebKernel(
+            configDir: $this->testConfigDir,
+            environment: 'dev',
+            container: $container,
+            logger: $logger,
+        );
+        $kernel->reset();
+
+        static::assertTrue($logger->wasReset, 'A ResettableInterface logger must be drained on kernel reset.');
     }
 
     public function testBootIsIdempotentOnceBooted(): void


### PR DESCRIPTION
- Update `AbstractKernel` to explicitly implement `TerminableInterface`.
- Add `#[\Override]` attributes to the `terminate` and `reset` methods in `AbstractKernel`.
- Update `AbstractKernel::reset()` to call `reset()` on the logger if it implements `ResettableInterface` to prevent log entries from bleeding across requests in worker mode.
- Add `testResetAlsoDrainsAResettableLogger` to `AbstractKernelTest` to verify that a resettable logger is properly drained when the kernel resets.
